### PR TITLE
Add generic backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added the `async-tempfile` crate feature to enable the `SharedTempFile`
   type.
-- Added the generic `SharedFile<T>` type for use with arbitrary `AsyncWrite + AsyncRead + Unpin` types.
+- Added the generic `SharedFile<T>` type for use with arbitrary `AsyncWrite + AsyncRead` types.
 
 ## [0.0.1] - 2023-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the `async-tempfile` crate feature to enable the `SharedTempFile`
+  type.
+- Added the generic `SharedFile<T>` type for use with arbitrary `AsyncWrite + AsyncRead + Unpin` types.
+
 ## [0.0.1] - 2023-06-13
 
 ### Internal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 rust-version = "1.68.0"
 
 [features]
+default = ["async-tempfile"]
 async-tempfile = ["dep:async-tempfile"]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,17 @@ authors = ["Markus Mayer"]
 edition = "2021"
 rust-version = "1.68.0"
 
+[features]
+async-tempfile = ["dep:async-tempfile"]
+
+[[test]]
+name = "parallel_write_read"
+path = "tests/parallel_write_read.rs"
+required-features = ["async-tempfile"]
+
 [dependencies]
-async-tempfile = "0.3.0"
+async-tempfile = { version = "0.3.0", optional = true }
+async-trait = "0.1.68"
 crossbeam = "0.8.2"
 pin-project = "1.1.0"
 thiserror = "1.0.40"
@@ -24,3 +33,6 @@ uuid = { version = "1.3.3", features = ["rng", "v1"] }
 rand = "0.8.5"
 tokio = { version = "1.28.2", features = ["rt", "macros", "rt-multi-thread", "io-util", "time"] }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ requires `AsyncWrite` and `AsyncRead`.
 
 ## Features
 
-- `async-tempfile`: Enables the `SharedTempFile` type via the [async-tempfile](https://github.com/sunsided/async-tempfile-rs)
+- `async-tempfile`: Enables the `SharedTemporaryFile` type via the [async-tempfile](https://github.com/sunsided/async-tempfile-rs)
   crate. Since this is how this crate was initially meant to be used, this feature is enabled by default.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Normally, reading a file while it is written results in the read stream ending p
 of this crate is to prevent exactly that.
 
 Any file type can be used as a backing as long as it implements the crate's `SharedFileType` trait, which in turn
-requires `AsyncWrite`, `AsyncRead` and `Unpin`.
+requires `AsyncWrite` and `AsyncRead`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ processing of byte streams with minimum (process) memory requirements, e.g. in w
 Normally, reading a file while it is written results in the read stream ending prematurely as EOF; the purpose
 of this crate is to prevent exactly that.
 
-The functionality is currently based on the [async-tempfile](https://github.com/sunsided/async-tempfile-rs) crate.
-A generic implementation is planned for the use of arbitrary `AsyncWrite` / `AsyncRead` backing.
+Any file type can be used as a backing as long as it implements the crate's `SharedFileType` trait, which in turn
+requires `AsyncWrite`, `AsyncRead` and `Unpin`.
+
+## Features
+
+- `async-tempfile`: Enables the `SharedTempFile` type via the [async-tempfile](https://github.com/sunsided/async-tempfile-rs)
+  crate. Since this is how this crate was initially meant to be used, this feature is enabled by default.
 
 ## Example
 
 See [`tests/parallel_write_read.rs`](tests/parallel_write_read.rs) for a usage example.
+The example requires the `async-tempfile` crate feature. To run it, use e.g.
+
+```shell
+cargo test parallel_write_read --features=async-tempfile
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Crate Features
 //!
-//! - `async-tempfile`: Enables the [`SharedTempFile`] type via the
+//! - `async-tempfile`: Enables the [`SharedTemporaryFile`] type via the
 //!   [async-tempfile](https://github.com/sunsided/async-tempfile-rs) crate. Since this is how
 //!   this crate was initially meant to be used, this feature is enabled by default.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@
 //! as EOF; the purpose of this crate is to prevent exactly that.
 //!
 //! Any file type can be used as a backing as long as it implements the crate's [`SharedFileType`]
-//! trait, which in turn requires [`AsyncWrite`](tokio::io::AsyncWrite), [`AsyncRead`](tokio::io::AsyncRead)
-//! and [`Unpin`].
+//! trait, which in turn requires [`AsyncWrite`](tokio::io::AsyncWrite) and [`AsyncRead`](tokio::io::AsyncRead).
 //!
 //! ## Crate Features
 //!

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,4 @@
-use crate::{Sentinel, State};
-use async_tempfile::TempFile;
+use crate::{Sentinel, SharedFileType, State};
 use pin_project::{pin_project, pinned_drop};
 use std::io::{Error, ErrorKind, SeekFrom};
 use std::pin::Pin;
@@ -11,21 +10,24 @@ use uuid::Uuid;
 
 /// A reader for the shared temporary file.
 #[pin_project(PinnedDrop)]
-pub struct SharedTemporaryFileReader {
+pub struct SharedFileReader<T> {
     /// The ID of the reader.
     id: Uuid,
     /// The file to read from.
     #[pin]
-    file: TempFile,
+    file: T,
     /// The sentinel value to keep the file alive.
-    sentinel: Arc<Sentinel>,
+    sentinel: Arc<Sentinel<T>>,
 }
 
 /// These IDs never leave the current system, so the node ID is arbitrary.
 static NODE_ID: &'static [u8; 6] = &[2, 3, 0, 6, 1, 2];
 
-impl SharedTemporaryFileReader {
-    pub(crate) fn new(file: TempFile, sentinel: Arc<Sentinel>) -> Self {
+impl<T> SharedFileReader<T>
+where
+    T: SharedFileType<Type = T>,
+{
+    pub(crate) fn new(file: T, sentinel: Arc<Sentinel<T>>) -> Self {
         Self {
             id: Uuid::now_v1(&NODE_ID),
             file,
@@ -34,7 +36,7 @@ impl SharedTemporaryFileReader {
     }
 
     /// Creates a new, independent reader.
-    pub async fn fork(&self) -> Result<Self, async_tempfile::Error> {
+    pub async fn fork(&self) -> Result<Self, T::OpenError> {
         Ok(Self {
             id: Uuid::now_v1(&NODE_ID),
             file: self.sentinel.original.open_ro().await?,
@@ -43,7 +45,7 @@ impl SharedTemporaryFileReader {
     }
 }
 
-impl SharedTemporaryFileReader {
+impl<T> SharedFileReader<T> {
     /// Gets the (expected) size of the file to read.
     pub fn file_size(&self) -> FileSize {
         match self.sentinel.state.load() {
@@ -67,13 +69,16 @@ pub enum FileSize {
 }
 
 #[pinned_drop]
-impl PinnedDrop for SharedTemporaryFileReader {
+impl<T> PinnedDrop for SharedFileReader<T> {
     fn drop(mut self: Pin<&mut Self>) {
         self.sentinel.remove_reader_waker(&self.id)
     }
 }
 
-impl AsyncRead for SharedTemporaryFileReader {
+impl<T> AsyncRead for SharedFileReader<T>
+where
+    T: AsyncRead,
+{
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -117,7 +122,10 @@ impl AsyncRead for SharedTemporaryFileReader {
     }
 }
 
-impl AsyncSeek for SharedTemporaryFileReader {
+impl<T> AsyncSeek for SharedFileReader<T>
+where
+    T: AsyncSeek,
+{
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
         let this = self.project();
         this.file.start_seek(position)

--- a/src/temp_file.rs
+++ b/src/temp_file.rs
@@ -1,7 +1,8 @@
-use crate::{AsyncNew, CompleteWritingError, FilePath, SharedFileType};
+use crate::{AsyncNewFile, CompleteWritingError, FilePath, SharedFileType};
 use async_tempfile::TempFile;
 use std::ops::Deref;
 use std::path::PathBuf;
+use tokio::fs::File;
 
 #[async_trait::async_trait]
 impl SharedFileType for TempFile {
@@ -18,16 +19,18 @@ impl SharedFileType for TempFile {
     }
 
     async fn sync_all(&self) -> Result<(), Self::SyncError> {
-        Ok(self.deref().sync_all().await?)
+        let file: &File = self.deref();
+        Ok(file.sync_all().await?)
     }
 
     async fn sync_data(&self) -> Result<(), Self::SyncError> {
-        Ok(self.deref().sync_data().await?)
+        let file: &File = self.deref();
+        Ok(file.sync_data().await?)
     }
 }
 
 #[async_trait::async_trait]
-impl AsyncNew for TempFile {
+impl AsyncNewFile for TempFile {
     type Target = TempFile;
     type Error = async_tempfile::Error;
 

--- a/src/temp_file.rs
+++ b/src/temp_file.rs
@@ -1,0 +1,43 @@
+use crate::{AsyncNew, CompleteWritingError, FilePath, SharedFileType};
+use async_tempfile::TempFile;
+use std::ops::Deref;
+use std::path::PathBuf;
+
+#[async_trait::async_trait]
+impl SharedFileType for TempFile {
+    type Type = TempFile;
+    type OpenError = async_tempfile::Error;
+    type SyncError = CompleteWritingError;
+
+    async fn open_ro(&self) -> Result<Self::Type, Self::OpenError> {
+        self.open_ro().await
+    }
+
+    async fn open_rw(&self) -> Result<Self::Type, Self::OpenError> {
+        self.open_rw().await
+    }
+
+    async fn sync_all(&self) -> Result<(), Self::SyncError> {
+        Ok(self.deref().sync_all().await?)
+    }
+
+    async fn sync_data(&self) -> Result<(), Self::SyncError> {
+        Ok(self.deref().sync_data().await?)
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncNew for TempFile {
+    type Target = TempFile;
+    type Error = async_tempfile::Error;
+
+    async fn new() -> Result<Self::Target, Self::Error> {
+        TempFile::new().await
+    }
+}
+
+impl FilePath for TempFile {
+    fn file_path(&self) -> &PathBuf {
+        self.file_path()
+    }
+}

--- a/src/temp_file.rs
+++ b/src/temp_file.rs
@@ -49,10 +49,10 @@ impl FilePath for TempFile {
 }
 
 /// A type alias for a [`SharedFile`] wrapping a [`TempFile`].
-pub type SharedTempFile = SharedFile<TempFile>;
+pub type SharedTemporaryFile = SharedFile<TempFile>;
 
 /// A type alias for a [`SharedFileReader`] wrapping a [`TempFile`].
-pub type SharedTempFileReader = SharedFileReader<TempFile>;
+pub type SharedTemporaryFileReader = SharedFileReader<TempFile>;
 
 /// A type alias for a [`SharedFileWriter`] wrapping a [`TempFile`].
-pub type SharedTempFileWriter = SharedFileWriter<TempFile>;
+pub type SharedTemporaryFileWriter = SharedFileWriter<TempFile>;

--- a/src/temp_file.rs
+++ b/src/temp_file.rs
@@ -1,4 +1,7 @@
-use crate::{AsyncNewFile, CompleteWritingError, FilePath, SharedFileType};
+use crate::{
+    AsyncNewFile, CompleteWritingError, FilePath, SharedFile, SharedFileReader, SharedFileType,
+    SharedFileWriter,
+};
 use async_tempfile::TempFile;
 use std::ops::Deref;
 use std::path::PathBuf;
@@ -44,3 +47,12 @@ impl FilePath for TempFile {
         self.file_path()
     }
 }
+
+/// A type alias for a [`SharedFile`] wrapping a [`TempFile`].
+pub type SharedTempFile = SharedFile<TempFile>;
+
+/// A type alias for a [`SharedFileReader`] wrapping a [`TempFile`].
+pub type SharedTempFileReader = SharedFileReader<TempFile>;
+
+/// A type alias for a [`SharedFileWriter`] wrapping a [`TempFile`].
+pub type SharedTempFileWriter = SharedFileWriter<TempFile>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Trait for types used as a file storage backend.
+#[async_trait::async_trait]
+pub trait SharedFileType: AsyncRead + AsyncWrite + Unpin {
+    /// The type created when producing a reader or writer. Typically `Self`.
+    type Type;
+
+    /// The error type.
+    type OpenError;
+
+    /// The error type.
+    type SyncError;
+
+    /// Opens a new [`Type`](Self::Type) instance in read-only mode.
+    async fn open_ro(&self) -> Result<Self::Type, Self::OpenError>;
+
+    /// Opens a new [`Type`](Self::Type) instance in read-write mode.
+    async fn open_rw(&self) -> Result<Self::Type, Self::OpenError>;
+
+    /// Synchronizes data and metadata with the underlying buffer.
+    async fn sync_all(&self) -> Result<(), Self::SyncError>;
+
+    /// Synchronizes data with the underlying buffer.
+    async fn sync_data(&self) -> Result<(), Self::SyncError>;
+}
+
+/// Trait for types that can be newly constructed asynchronously.
+#[async_trait::async_trait]
+pub trait AsyncNew {
+    /// The type created on success.
+    type Target;
+    /// The error type.
+    type Error;
+
+    /// Creates a new instance of the type [`Target`](AsyncNew::Target).
+    async fn new() -> Result<Self::Target, Self::Error>;
+}
+
+/// Trait for types that can synchronously determine the file path.
+pub trait FilePath {
+    /// Obtains the path of the temporary file.
+    fn file_path(&self) -> &PathBuf;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -28,14 +28,25 @@ pub trait SharedFileType: AsyncRead + AsyncWrite + Unpin {
 
 /// Trait for types that can be newly constructed asynchronously.
 #[async_trait::async_trait]
-pub trait AsyncNew {
+pub trait AsyncNewFile {
     /// The type created on success.
     type Target;
     /// The error type.
     type Error;
 
-    /// Creates a new instance of the type [`Target`](AsyncNew::Target).
+    /// Creates a new instance of the type [`Target`](AsyncNewFile::Target).
     async fn new() -> Result<Self::Target, Self::Error>;
+}
+
+/// Trait for types that can be newly constructed asynchronously.
+pub trait NewFile {
+    /// The type created on success.
+    type Target;
+    /// The error type.
+    type Error;
+
+    /// Creates a new instance of the type [`Target`](AsyncNewFile::Target).
+    fn new() -> Result<Self::Target, Self::Error>;
 }
 
 /// Trait for types that can synchronously determine the file path.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Trait for types used as a file storage backend.
 #[async_trait::async_trait]
-pub trait SharedFileType: AsyncRead + AsyncWrite + Unpin {
+pub trait SharedFileType: AsyncRead + AsyncWrite {
     /// The type created when producing a reader or writer. Typically `Self`.
     type Type;
 

--- a/tests/parallel_write_read.rs
+++ b/tests/parallel_write_read.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;
 
-use shared_files::{FileSize, SharedTempFile, SharedTempFileReader};
+use shared_files::{FileSize, SharedTemporaryFile, SharedTemporaryFileReader};
 
 /// The number of u16 values to write.
 const NUM_VALUES_U16: usize = 65_536;
@@ -16,7 +16,7 @@ const NUM_BYTES: usize = NUM_VALUES_U16 * std::mem::size_of::<u16>();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parallel_write_read() {
-    let file = SharedTempFile::new_async()
+    let file = SharedTemporaryFile::new_async()
         .await
         .expect("failed to create file");
 
@@ -64,7 +64,7 @@ fn validate_result(read: Vec<u8>) {
 }
 
 /// Writes with arbitrary delays.
-async fn parallel_write(file: SharedTempFile) {
+async fn parallel_write(file: SharedTemporaryFile) {
     let mut writer = file.writer().await.expect("failed to create writer");
 
     for i in 0..NUM_VALUES_U16 {
@@ -86,7 +86,7 @@ async fn parallel_write(file: SharedTempFile) {
 }
 
 /// Reads while the writer is still active.
-async fn parallel_read(mut reader: SharedTempFileReader) -> Vec<u8> {
+async fn parallel_read(mut reader: SharedTemporaryFileReader) -> Vec<u8> {
     let mut results = Vec::default();
     let mut buf = [0u8; 1024];
     loop {


### PR DESCRIPTION
This PR adds generic storage backends and introduces the `async-tempfile` (default) crate feature. With this change, any `AsyncWrite`, `AsyncRead` and `Unpin` type can be used instead of `async_tempfile::TempFile`.