### PR TITLE
Prevent reading more than was written

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ path = "tests/parallel_write_read.rs"
 required-features = ["async-tempfile"]
 
 [[test]]
+name = "nodelay"
+path = "tests/nodelay.rs"
+required-features = ["async-tempfile"]
+
+[[test]]
 name = "read_exact"
 path = "tests/read_exact.rs"
 required-features = ["async-tempfile"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ name = "parallel_write_read"
 path = "tests/parallel_write_read.rs"
 required-features = ["async-tempfile"]
 
+[[test]]
+name = "read_exact"
+path = "tests/read_exact.rs"
+required-features = ["async-tempfile"]
+
 [dependencies]
 async-tempfile = { version = "0.3.0", optional = true }
 async-trait = "0.1.68"

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ See [`tests/parallel_write_read.rs`](tests/parallel_write_read.rs) for a usage e
 The example requires the `async-tempfile` crate feature. To run it, use e.g.
 
 ```shell
-cargo test parallel_write_read --features=async-tempfile
+cargo test --test parallel_write_read --features=async-tempfile
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod writer;
 use crossbeam::atomic::AtomicCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 use std::task::Waker;
 use uuid::Uuid;
 
@@ -61,9 +61,9 @@ struct Sentinel<T> {
 /// The state of a file write operation.
 #[derive(Debug, Clone, Copy)]
 enum WriteState {
-    /// The write operation is pending. Contains the number of bytes written.
-    Pending(usize),
-    /// The write operation completed. Contains the file size.
+    /// The write operation is pending. Contains the committed byte count and the written byte count.
+    Pending(usize, usize),
+    /// The write operation completed. Contains the number of bytes written (and committed).
     Completed(usize),
     /// The write operation failed.
     Failed,
@@ -114,7 +114,7 @@ impl<T> From<T> for SharedFile<T> {
         Self {
             sentinel: Arc::new(Sentinel {
                 original: value,
-                state: AtomicCell::new(WriteState::Pending(0)),
+                state: AtomicCell::new(WriteState::Pending(0, 0)),
                 wakers: Mutex::new(HashMap::default()),
             }),
         }
@@ -129,7 +129,7 @@ where
         Self {
             sentinel: Arc::new(Sentinel {
                 original: T::default(),
-                state: AtomicCell::new(WriteState::Pending(0)),
+                state: AtomicCell::new(WriteState::Pending(0, 0)),
                 wakers: Mutex::new(HashMap::default()),
             }),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod writer;
 use crossbeam::atomic::AtomicCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::task::Waker;
 use uuid::Uuid;
 

--- a/src/temp_file.rs
+++ b/src/temp_file.rs
@@ -2,7 +2,7 @@ use crate::{
     AsyncNewFile, CompleteWritingError, FilePath, SharedFile, SharedFileReader, SharedFileType,
     SharedFileWriter,
 };
-use async_tempfile::TempFile;
+use async_tempfile::{Ownership, TempFile};
 use std::ops::Deref;
 use std::path::PathBuf;
 use tokio::fs::File;
@@ -56,3 +56,23 @@ pub type SharedTemporaryFileReader = SharedFileReader<TempFile>;
 
 /// A type alias for a [`SharedFileWriter`] wrapping a [`TempFile`].
 pub type SharedTemporaryFileWriter = SharedFileWriter<TempFile>;
+
+impl SharedTemporaryFile {
+    /// Wraps a new instance of this type around an existing file. This is a convencience
+    /// wrapper around [`TempFile::from_existing`] and [`SharedFile::from`].
+    ///
+    /// If `ownership` is set to [`Ownership::Borrowed`], this method does not take ownership of
+    /// the file, i.e. the file will not be deleted when the instance is dropped.
+    ///
+    /// ## Arguments
+    ///
+    /// * `path` - The path of the file to wrap.
+    /// * `ownership` - The ownership of the file.
+    pub async fn from_existing(
+        path: PathBuf,
+        ownership: Ownership,
+    ) -> Result<SharedFile<TempFile>, async_tempfile::Error> {
+        let file = TempFile::from_existing(path, ownership).await?;
+        Ok(Self::from(file))
+    }
+}

--- a/tests/read_exact.rs
+++ b/tests/read_exact.rs
@@ -115,7 +115,6 @@ async fn parallel_write(file: SharedTemporaryFile) {
             let t = thread_rng().gen_range(1..1000);
             sleep(Duration::from_micros(t)).await;
 
-            // This sync will also wake up the consumers.
             writer.sync_data().await.expect("failed to sync data");
         }
     }

--- a/tests/read_exact.rs
+++ b/tests/read_exact.rs
@@ -20,7 +20,7 @@ use shared_files::{
 const NUM_PREFILL_VALUES_U16: usize = 65_536;
 
 /// The number of u16 values to write.
-const NUM_VALUES_U16: usize = 1024;
+const NUM_VALUES_U16: usize = 3_724;
 
 /// The number of bytes occupied by the written values.
 const NUM_BYTES: usize = NUM_VALUES_U16 * std::mem::size_of::<u16>();
@@ -93,6 +93,9 @@ async fn prefill_file(file: SharedTemporaryFile) -> SharedTemporaryFile {
                 .await
                 .expect("failed to write");
         }
+
+        // Ensure data is flushed to disk.
+        writer.sync_all().await.expect("failed to sync");
     }
 
     file


### PR DESCRIPTION
When re-using an already existing file buffer, the read operation would eagerly read to the end of the file, advancing the read stream even if nothing was committed by the writer yet. This PR contains changes that prevent this behavior.